### PR TITLE
bug 104729 - Reorg State Machine Config/Processing

### DIFF
--- a/resources/defaults.edn
+++ b/resources/defaults.edn
@@ -1,17 +1,10 @@
-{;;; Local node configuration
- :node {;; each node should have a unique identifier
+{:node {;; each node should have a unique identifier
         :id :n0
         ;; human-friendly name for the node
         :name "node0"
         ;; Inter-node communications
         :endpoint {;; HTTP address:port to bind to
                    :http "0.0.0.0:2283"}
-        ;; Default location for configuration
-        :config-dir "/opt/zimbra/simioj/conf"
-        ;; Default location for logs
-        :log-dir "/opt/zimbra/simioj/log"
-        ;; Default location for replicated log/cache data
-        :data-dir "/opt/zimbra/simioj/data"
         ;; Jetty configuration
         :worker {:count 4 :threads 4}
         ;; This location is added to the classpath and should contain
@@ -45,15 +38,38 @@
              ;; (2) we have quorum and quorum-timeout milliseconds have elapsed
              :quorum-timeout 30000}
  ;;; Configuration for the Raft that will be started by the API
- :raft {;; Raft log implementation (:sqlite, :memory)
-        :log {:type :sqlite :args {}}
-        ;; Initial server-config.  :servers is a vector that may contain
-        ;; 0, 1, or 2 sets of server IDs; e.g., [#{:s0 :s1 :s2}]
-        :server-config {:servers []}
-        ;; Initial server-state
+ :raft {;; ID of raft server.
+        :id :s0
+        ;; Base path for location where raft data is stored.
+        ;; The following subdirectories will be created
+        ;;   :prefix/<raft-id>/config
+        ;;   :prefix/<raft-id>/state
+        ;;   :prefix/<raft-id>/snapshots
+        :prefix "/opt/zimbra/simioj/data"
+        ;; Raft log initialization function / args
+        :log {:fn "" :args ()}
+        ;; Raft rpc initialization function / args
+        :rpc {:fn "" :args ()}
+        ;; Raft election config
+        :election-config {:broadcast-timeout 10 :election-timeout-min 150 :election-timeout-max 300}
+        ;; Initial servers-config.
+        ;; May contain the following entries
+        ;; :leader <leader-id> - If using leader affinity
+        ;; :servers is a vector that may contain
+        ;;   0 or 1 sets of server identifiers; e.g., [#{:s0 :s1 :s2}]
+        ;;   These are all the servers that are members of the Raft cluster
+        ;; :state-processers - a map of state-machine-processor initializers
+        ;; :state-change-listeners - a map of state-change-listener callback initializers
+        ;; The following initialized directory paths are injected into the :servers-config
+        ;; on start-up, based upon the :prefix and :id
+        ;; :config, :state, :snapshots
+        :servers-config {:servers []}
+        ;; Initial server-state.
+        ;; Notes: If a server has persisted state when it starts up, the
+        ;;          :server-state config is not used.
+        ;;        Upon startup, the following is injected into :server-state
+        ;;          from the initialization values provided in :severs-config
+        ;;          :leader
+        ;;          :servers
         :server-state {}
-        ;; Additional statemachines to be configured
-        ;; keys should be a keyword to use for an identifier
-        ;; values should be fully-qualified classes
-        :statemachines {}
         }}

--- a/resources/mn0.edn
+++ b/resources/mn0.edn
@@ -1,17 +1,16 @@
 {:node {:id :n0
         :name "node0"
-        :endpoint {:http "0.0.0.0:2280"}
-        :config-dir "test-data/conf"
-        :log-dir "test-data/log"
-        :data-dir "test-data/data"}
+        :endpoint {:http "0.0.0.0:2280"}}
  :raft {:id :s0
+        :prefix "test-data"
         :log {:fn "zimbra.simioj.raft.log/make-memory-log" :args ()}
         :rpc {:fn "zimbra.simioj.endpoint.http/make-http-rpc"
-              :args ({:servers {:s0 {:endpoint {:http "127.0.0.1:2280"}} :s1 {:endpoint {:http "127.0.0.1:2281"}} :s2 {:endpoint {:http "127.0.0.1:2282"}}}})}
+              :args ({:servers {:s0 {:endpoint {:http "127.0.0.1:2280"}}
+                                :s1 {:endpoint {:http "127.0.0.1:2281"}}
+                                :s2 {:endpoint {:http "127.0.0.1:2282"}}}})}
         :election-config {:broadcast-timeout 100 :election-timeout-min 1000 :election-timeout-max 5000}
-        :leader-state {}
-        :servers-config {:servers [#{:s0 :s1 :s2}]
-                         :leader :s0
-                         :state-machines {:kv {:fn "zimbra.simioj.raft.statemachine/make-memory-state-machine"
-                                                  :args (:patch (ref {}))}}}
+        :servers-config {:leader :s0
+                         :servers [#{:s0 :s1 :s2}]
+                         :state-processors {:kv {:fn "zimbra.simioj.raft.statemachine/make-memory-state-processor"
+                                                 :args (:patch (ref {}))}}}
         :server-state {}}}

--- a/resources/mn1.edn
+++ b/resources/mn1.edn
@@ -1,17 +1,16 @@
 {:node {:id :n1
         :name "node1"
-        :endpoint {:http "0.0.0.0:2281"}
-        :config-dir "test-data/conf"
-        :log-dir "test-data/log"
-        :data-dir "test-data/data"}
- :raft {:id :s1
+        :endpoint {:http "0.0.0.0:2281"}}
+ :raft {:id :s0
+        :prefix "test-data"
         :log {:fn "zimbra.simioj.raft.log/make-memory-log" :args ()}
         :rpc {:fn "zimbra.simioj.endpoint.http/make-http-rpc"
-              :args ({:servers {:s0 {:endpoint {:http "127.0.0.1:2280"}} :s1 {:endpoint {:http "127.0.0.1:2281"}} :s2 {:endpoint {:http "127.0.0.1:2282"}} }})}
+              :args ({:servers {:s0 {:endpoint {:http "127.0.0.1:2280"}}
+                                :s1 {:endpoint {:http "127.0.0.1:2281"}}
+                                :s2 {:endpoint {:http "127.0.0.1:2282"}}}})}
         :election-config {:broadcast-timeout 100 :election-timeout-min 1000 :election-timeout-max 5000}
-        :leader-state {}
-        :servers-config {:servers [#{:s0 :s1 :s2}]
-                         :leader :s0
-                         :state-machines {:kv {:fn "zimbra.simioj.raft.statemachine/make-memory-state-machine"
-                                                  :args (:patch (ref {}))}}}
+        :servers-config {:leader :s1
+                         :servers [#{:s0 :s1 :s2}]
+                         :state-processors {:kv {:fn "zimbra.simioj.raft.statemachine/make-memory-state-processor"
+                                                 :args (:patch (ref {}))}}}
         :server-state {}}}

--- a/resources/mn2.edn
+++ b/resources/mn2.edn
@@ -1,17 +1,16 @@
 {:node {:id :n2
         :name "node2"
-        :endpoint {:http "0.0.0.0:2282"}
-        :config-dir "test-data/conf"
-        :log-dir "test-data/log"
-        :data-dir "test-data/data"}
- :raft {:id :s2
+        :endpoint {:http "0.0.0.0:2282"}}
+ :raft {:id :s0
+        :prefix "test-data"
         :log {:fn "zimbra.simioj.raft.log/make-memory-log" :args ()}
         :rpc {:fn "zimbra.simioj.endpoint.http/make-http-rpc"
-              :args ({:servers {:s0 {:endpoint {:http "127.0.0.1:2280"}} :s1 {:endpoint {:http "127.0.0.1:2281"}} :s2 {:endpoint {:http "127.0.0.1:2282"}} }})}
+              :args ({:servers {:s0 {:endpoint {:http "127.0.0.1:2280"}}
+                                :s1 {:endpoint {:http "127.0.0.1:2281"}}
+                                :s2 {:endpoint {:http "127.0.0.1:2282"}}}})}
         :election-config {:broadcast-timeout 100 :election-timeout-min 1000 :election-timeout-max 5000}
-        :leader-state {}
-        :servers-config {:servers [#{:s0 :s1 :s2}]
-                         :leader :s0
-                         :state-machines {:kv {:fn "zimbra.simioj.raft.statemachine/make-memory-state-machine"
-                                                  :args (:patch (ref {}))}}}
+        :servers-config {:leader :s2
+                         :servers [#{:s0 :s1 :s2}]
+                         :state-processors {:kv {:fn "zimbra.simioj.raft.statemachine/make-memory-state-processor"
+                                                 :args (:patch (ref {}))}}}
         :server-state {}}}

--- a/src/zimbra/simioj/endpoint/http.clj
+++ b/src/zimbra/simioj/endpoint/http.clj
@@ -92,9 +92,6 @@ POST <command> - Post a command to the Raft
 (defn state-handler
   "Retrieve state values"
   [ctx state-machine resource-id req]
-  (logger/infof "state-handler: state-machine=%s (%s), resource-id=%s (%s)"
-                state-machine (type state-machine)
-                resource-id (type resource-id))
   (let [raft (:raft @ctx)
         sm (keyword (clojure.string/replace state-machine #":" ""))
         resp (if (nil? resource-id)
@@ -113,11 +110,9 @@ POST <command> - Post a command to the Raft
   [ctx req]
   (let [raft (:raft @ctx)]
     (logger/tracef "status-handler: id=%s, servers-config=%s"
-                   (:id raft)
-                   (:servers-config raft))
+                   (:id raft))
     {:status 200
      :body {:id (:id raft)
-            :servers-config (assoc @(:servers-config raft) :state-machines (keys (:state-machines @(:servers-config raft))))
             :server-state @(:server-state raft)
             :leader-state @(:leader-state raft)}}))
 

--- a/src/zimbra/simioj/raft/statemachine.clj
+++ b/src/zimbra/simioj/raft/statemachine.clj
@@ -9,9 +9,8 @@
   (:gen-class))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;; Protocol
+;;;; Protocols
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
 
 (defprotocol StateMachine
   "The StateMachine receives commands from (internal) clients.  Each command
@@ -26,34 +25,49 @@
   ALWAYS processes a :set-config log entry immediately, regardless of the
   commit-index.
 
-  Implementer's Notes:
+  Our implementation of StateMachine allows for the registration of
+  an arbitrary number of StateProcessors.  Each StateProcessor
+  can operate on a given command. More than one StateProcessor
+  can operate on the same command.
 
-  1. The Raft :leader has to invoke the state machine's process-log!
-     twice for every command that it receives.  It is invoked immediately
-     after storing the command locally.  This gives any state machines
-     that can operate on pre-committed log entries the opportunity
-     to do so.  The state machine that processes :set-config commands
-     it the primary one that needs to run.  Then, after it has replicated
-     the command to its followers, the process-log! must be invoked again
-     to allow log entries that are now commited to be processed.
+  A StateProcessor implements the following functions from the StateMachine
+  protocol:
 
-     Therefore, when implementing a state machine, the first thing it
-     should do is check to see if it is allowed to run by comparing
-     its last-applied with the commit-index.
-  2. If a state machine encounters a commited log command that it
-     does not handle, it should still increment it's last-applied
-     value.
+    process-command!
+    get-state
+
+  Implementation Notes
+
+  Any processor implementation must provide a function to construct an instance
+  of that processor.  It is required that all such functions accept an first
+  DIRS-MAP artument that is a map with the following entries.
+    {:config <config-dir-path>
+     :state <state-dir-path>
+     :snapshots <snapshots-dir-path>}
+  These directories are guaranteed to pre-exist.  It is not required that
+  the specific implmentation use this argument.
   "
-  (process-log! [this log commit-index last-applied]
-    "Process applicable log entries.
+  (process-set-config! [this command]
+    "Immediately process COMMAND, if it is a :set-config. Else
+    is a no-op.
+    Returns:
+    {:applied? true|false
+     :state-changed? true (if :applied? and :old-state != :new-state)
+     :old-state <old-state> (if :applied?, else not included)
+     :new-state <new-state> (if :applied?, else not included)}
+    ")
+  (process-command! [this command]
+    "Process COMMAND from log.  The command must have been committed before
+     calling this function.
      Parameters:
        LOG - A Raft log instance
-       COMMIT-INDEX - The Server's commit index
-       LAST-APPLIED - The last log entry applied by this state machine
-     Returns an updated value to use for :last-applied.  The server is
-     responsible for remembering this.
-    "
-    )
+       COMMAND - The command to process.
+    Returns:
+    {:applied? true|false
+     :state-changed? true (if :applied? and :old-state != :new-state)
+     :old-state <old-state> (if :applied? and :state-changed?, else not included)
+     :new-state <new-state> (if :applied? and :state-changed?, else not included)}
+    ")
   (get-state [this] [this resource-id] [this resource-id default]
     "Retrieve the computed state of the StateMachine If RESOURCE-ID is supplied
     (and if it is supported by the StateMachine, return the computed state
@@ -61,125 +75,86 @@
     exist and DEFAULT is supplied, that is returned, else nil is returned.
 
     Response: The requested state value
-    ")
-  (add-state-change-listener [this listener]
+    "))
+
+
+(defprotocol StateChangedNotifier
     "State machines may choose to, by design, provide notifications when
      their state changes.  Interested parties may register a function that
      will by called with the following arguments when the state changes:
-         (<old-state> <new-state>)
+         (<command-id> <old-state> <new-state>)
      What is meant by \"state\" may vary depending upon the state machine
      implementation.   For example, the state machine that handles
      object patches may choose to return the original state of the object
      (before appling a patch) as old-state and the new state of the object
-     (after applying the patch) as the new-state.
-     Returns the current state as of the time this function is called.
-     ")
-  (remove-state-change-listener [this listener]
-    "Deregister the specified LISTENER function.  Returns a non-nil value
-    if LISTENER was found, else nil.")
-  (notify-state-changed [this old-state new-state]
-    "Notify all of the registered listeners of a state change."))
+     (after applying the patch) as the new-state."
+
+  (notify-state-changed [this command-id old-state new-state]
+    "Notify all of the registered listeners of a state change.
+     Parameters:
+     COMMAND-ID - The command identifier; e.g., :set-config, :patch, etc.
+     OLD-STATE - The state prior to command application
+     NEW-STATE - The state after command application"))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;; Sample memory State Machine Implementation (testing only)
+;;;; Sample memory State Processor Implementation (testing only)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defmulti msm-process-log-command!
-  "Used by MemoryStateMachine instance to process log commands
+(defmulti msm-process-command!
+  "Used by MemoryStateProcessor instance to process log commands
    Parameters:
      my-cmd - the command my instance is interested in
-     idx - the log index
      cmd-key - the command to be processed; e.g., :noop, :set-config, :patch
      cmd-val - the value associated with the command
-     commit-index - the server's commit index
      cache - Any state-machine-specific cache (ref)
    Returns: {:applied? <bool> :state-changed? <bool> :old-state <map> :new-state <map>}
   "
-  (fn [my-cmd idx cmd-key cmd-val commit-index cache] my-cmd)
+  (fn [my-cmd cmd-key cmd-val cache] my-cmd)
   :default :noop)
 
 
-(defmethod msm-process-log-command! :patch
-  [my-cmd idx cmd-key cmd-val commit-index cache]
-  (if (<= idx commit-index)
-    (if (= my-cmd cmd-key)
-      (let [{:keys [:oid :ops :upsert]} cmd-val
-            res-old (@cache oid)
-            res-new (or (reduce (fn [r f]
-                                  ((if (fn? f) f (eval f)) r)) (or res-old upsert) ops) res-old)]
-        (if (not= res-old res-new)
-          (do
-            (dosync (alter cache assoc oid res-new))
-            {:applied? true
-             :state-changed? true
-             :old-state {:oid oid :val res-old}
-             :new-state {:oid oid :val res-new}})
-          {:applied? true :state-changed? false}))
-      {:applied? true :state-changed? false})
-    {:applied? false :state-changed? false}))
-
-(defmethod msm-process-log-command! :set-config
-  ;; config changes are always applied, whether or not
-  ;; the command has been committed
-  [my-cmd idx cmd-key cmd-val commit-index cache]
+(defmethod msm-process-command! :patch
+  [my-cmd cmd-key cmd-val cache]
   (if (= my-cmd cmd-key)
-    (let [old-state @cache
-          new-state (dosync (alter cache merge cmd-val))]
-      {:applied? true
-       :state-changed? (not= old-state new-state)
-       :old-state old-state
-       :new-state new-state})
+    (let [{:keys [:oid :ops :upsert]} cmd-val
+          res-old (@cache oid)
+          res-new (or (reduce (fn [r f]
+                                ((if (fn? f) f (eval f)) r)) (or res-old upsert) ops) res-old)]
+      (if (not= res-old res-new)
+        (do
+          (dosync (alter cache assoc oid res-new))
+          {:applied? true
+           :state-changed? true
+           :old-state {:oid oid :val res-old}
+           :new-state {:oid oid :val res-new}})
+        {:applied? true :state-changed? false}))
     {:applied? true :state-changed? false}))
 
 
-(defmethod msm-process-log-command! :noop
-  [my-cmd idx cmd-key cmd-val commit-index cache]
-  (if (<= idx commit-index)
-    {:applied? true :state-changed? false}
-    {:applied? false :state-changed? false}))
+  (defmethod msm-process-command! :noop
+    [my-cmd cmd-key cmd-val cache]
+    {:applied? true :state-changed? false})
 
 
-(deftype MemoryStateMachine [cmd cache listeners]
+
+(deftype MemoryStateProcessor [cmd cache]
   StateMachine
-  (process-log! [this log commit-index last-applied]
-    (logger/tracef "process-log!: cmd=%s, commit-index=%s, last=applied=%s"
-                cmd commit-index last-applied)
-    (let [[lidx lterm] (last-id-term log)
-          examine-indices (range (inc last-applied) (inc lidx))]
-      (loop [indices examine-indices
-             new-last-applied last-applied]
-        (if (empty? indices)
-          new-last-applied
-          (let [i (first indices)
-                entry (get-entry log i)]
-            (when entry  ; safety check
-              (let [[cmd-key cmd-val] (:command entry)
-                    {:keys [:applied? :state-changed? :old-state :new-state]}
-                    (msm-process-log-command! cmd i cmd-key cmd-val commit-index cache)]
-                (when state-changed?
-                  (notify-state-changed this old-state new-state))
-                (if applied?
-                  (recur (rest indices) i)
-                  (recur '() new-last-applied)))))))))
+  (process-command! [this [cmd-key cmd-val]]
+    (msm-process-command! cmd cmd-key cmd-val cache))
   (get-state [this]
     @cache)
   (get-state [this resource-id]
     (get-state this resource-id nil))
   (get-state [this resource-id default]
-    (@cache resource-id default))
-  (add-state-change-listener [this listener]
-    (dosync (alter listeners conj listener))
-    (get-state this))
-  (remove-state-change-listener [this listener]
-    (dosync (ref-set listeners (remove #(= listener %) @listeners))))
-  (notify-state-changed [this old-state new-state]
-    (dorun (pmap #(apply % [old-state new-state]) @listeners))))
+    (@cache resource-id default)))
 
 
 
-(defn make-memory-state-machine
-  "Construct an instance of a MemoryStateMachine.
-   Parameters;
+(defn make-memory-state-processor
+  "Construct an instance of a MemoryStateProcessor.
+   Parameters: A map with the following keys, at a minimum:
+     _dirs_map - not used
      cmd - The log command this state machine should handle.  Actual production
        state machines wouldn't necessarily need this parameter.  It is required
        here because the sample MemoryStateMachine uses a multi-method to dispatch
@@ -188,7 +163,6 @@
      cache - A map, wrapped in a ref.
        If it contains data, that will be the initial state of the
        state machine.  This function will wrap that in a ref.
-     listeners - An optional list of listener functions that will be called
-       when this machine's state changes.
   "
-  [cmd cache & listeners] (->MemoryStateMachine cmd cache (ref listeners)))
+  [_dirs-map cmd cache]
+  (->MemoryStateProcessor cmd cache))

--- a/test/zimbra/simioj/log_test.clj
+++ b/test/zimbra/simioj/log_test.clj
@@ -32,10 +32,13 @@
 
 (deftest memory-log-basic-test
   (testing "memory-log: basic tests"
-    (log-basic-test (make-memory-log))))
+    (log-basic-test (make-memory-log nil))))
 
 (deftest sqlite-log-basic-test
   (testing "sqlite-log: basic tests"
     (with-temp-file-path log-file ".dat"
       (with-cleanup-file-path log-file
-        (log-basic-test (make-sqlite-log log-file))))))
+        (let [path-parts (clojure.string/split log-file #"/")
+              dir-path (clojure.string/join "/" (butlast path-parts))
+              name (last path-parts)]
+          (log-basic-test (make-sqlite-log {:state dir-path} name)))))))

--- a/test/zimbra/simioj/raft_command_test.clj
+++ b/test/zimbra/simioj/raft_command_test.clj
@@ -8,7 +8,7 @@
 
 (deftest single-server-test
   (testing "Basic commands sent to single server"
-    (let [log (make-memory-log)
+    (let [log (make-memory-log nil)
           s0 (make-simple-raft-server
               :s0 log nil {} ; id log rpc ec
               {:servers [#{:s0}]} ; sc
@@ -29,12 +29,12 @@
     (let [sm (ref {})
           rpc (->TestRpc sm)
           s0 (make-simple-raft-server
-              :s0 (make-memory-log) rpc {} ; id log rpc ec
+              :s0 (make-memory-log nil) rpc {} ; id log rpc ec
               {:servers [#{:s0 :s1}]} ; sc
               {:state :leader :current-term 1 :commit-index 0 :voted-for :s0} ; ss
               {}) ; ls
           s1 (make-simple-raft-server
-              :s1 (make-memory-log) rpc {}
+              :s1 (make-memory-log nil) rpc {}
               {:servers [#{:s0 :s1}]} ; sc
               {:state :follower :current-term 1 :commit-index 0 :voted-for :s0} ; ss
               {}) ; ls
@@ -53,12 +53,12 @@
     (let [sm (ref {})
           rpc (->TestRpc sm)
           s0 (make-simple-raft-server
-              :s0 (make-memory-log) rpc {} ; id log rpc ec
+              :s0 (make-memory-log nil) rpc {} ; id log rpc ec
               {:servers [#{:s0 :s1}]} ; sc
               {:state :leader :current-term 1 :commit-index 0 :voted-for :s0} ; ss
               {}) ; ls
           s1 (make-simple-raft-server
-              :s1 (make-memory-log) rpc {}
+              :s1 (make-memory-log nil) rpc {}
               {:servers [#{:s0 :s1}]} ; sc
               {:state :follower :current-term 2 :commit-index 0 :voted-for :s0} ; ss
               {}) ; ls

--- a/test/zimbra/simioj/raft_election_test.clj
+++ b/test/zimbra/simioj/raft_election_test.clj
@@ -25,16 +25,16 @@
           raft-rpc (->TestRpc raft-servers)
           sc {:servers [#{:s0 :s1 :s2}]}
           ec {:broadcast-timeout 10 :election-timeout-min 150 :election-timeout-max 300}
-          s0 (make-server raft-servers :s0 (make-memory-log) raft-rpc ec sc
+          s0 (make-server raft-servers :s0 (make-memory-log {}) raft-rpc ec sc
                           {:state :leader :current-term 1 :voted-for :s0
                            :commit-index 0 :last-applied 0}
                           {:s1 {:next-index 1 :match-index 0}
                            :s2 {:next-index 1 :match-index 0}})
-          s1 (make-server raft-servers :s1 (make-memory-log) raft-rpc ec sc
+          s1 (make-server raft-servers :s1 (make-memory-log {}) raft-rpc ec sc
                           {:state :follower :current-term 1 :voted-for :s0
                            :commit-index 0 :last-applied 0}
                           {})
-          s2 (make-server raft-servers  :s2 (make-memory-log) raft-rpc ec sc
+          s2 (make-server raft-servers  :s2 (make-memory-log {}) raft-rpc ec sc
                           {:state :follower :current-term 1 :voted-for :s0
                            :commit-index 0 :last-applied 0}
                           {})]
@@ -55,15 +55,15 @@
           sc {:servers [#{:s0 :s1 :s2}]}
           ec {:broadcast-timeout 10 :election-timeout-min 150 :election-timeout-max 300}
           ecf {:broadcast-timeout 10 :election-timeout-min 300 :election-timeout-max 600}
-          s0 (make-server raft-servers :s0 (make-memory-log) raft-rpc ec sc
+          s0 (make-server raft-servers :s0 (make-memory-log {}) raft-rpc ec sc
                           {:current-term 0
                            :commit-index 0 :last-applied 0}
                           {})
-          s1 (make-server raft-servers :s1 (make-memory-log) raft-rpc ec sc
+          s1 (make-server raft-servers :s1 (make-memory-log {}) raft-rpc ec sc
                           {:current-term 0
                            :commit-index 0 :last-applied 0}
                           {})
-          s2 (make-server raft-servers :s2 (make-memory-log) raft-rpc ec sc
+          s2 (make-server raft-servers :s2 (make-memory-log {}) raft-rpc ec sc
                           {:current-term 0
                            :commit-index 0 :last-applied 0}
                           {})]
@@ -88,27 +88,24 @@
 
 (deftest three-server-configured-election-test
   (testing "test configured election"
-    ;; start :s1 and :s2 with larger election timeouts to guarantee that :s0
-    ;; wins initial election
     (let [raft-servers (ref {})
           raft-rpc (->TestRpc raft-servers)
-          sc {:servers [#{:s0 :s1 :s2}]}
-          ec {:broadcast-timeout 100 :election-timeout-min 500 :election-timeout-max 1000}
-          ecf {:broadcast-timeout 100 :election-timeout-min 1000 :election-timeout-max 1500}
-          s0 (make-server raft-servers :s0 (make-memory-log) raft-rpc ec sc
+          sc {:servers [#{:s0 :s1 :s2}] :leader :s0}
+          ec {:broadcast-timeout 1000 :election-timeout-min 1500 :election-timeout-max 3000}
+          s0 (make-server raft-servers :s0 (make-memory-log {}) raft-rpc ec sc
                           {:current-term 0
                            :commit-index 0 :last-applied 0}
                           {})
-          s1 (make-server raft-servers :s1 (make-memory-log) raft-rpc ecf sc
+          s1 (make-server raft-servers :s1 (make-memory-log {}) raft-rpc ec sc
                           {:current-term 0
                            :commit-index 0 :last-applied 0}
                           {})
-          s2 (make-server raft-servers :s2 (make-memory-log) raft-rpc ecf sc
+          s2 (make-server raft-servers :s2 (make-memory-log {}) raft-rpc ec sc
                           {:current-term 0
                            :commit-index 0 :last-applied 0}
                           {})]
       (dorun (map follower! [s0 s1 s2]))
-      (Thread/sleep 1000)
+      (Thread/sleep 3000)
       ;; (println "----- Server States 1 -----")
       ;; (doseq [s [s0 s1 s2]]
       ;;   (printf "Server=%s, State=%s\n"
@@ -118,8 +115,8 @@
       (is (= :leader (:state @(:server-state s0))))
       (is (= :follower (:state @(:server-state s1))))
       (is (= :follower (:state @(:server-state s2))))
-      ;; update servers-config to turn on configured election
-      (dorun (map #(dosync (ref-set (:servers-config %) (assoc sc :leader :s2))) [s0 s1 s2]))
+      ;; Switch leader affinity to :s2
+      (dorun (map #(dosync (ref-set (:server-state %) (assoc sc :leader :s2))) [s0 s1 s2]))
       (Thread/sleep 3000)
       ;; (println "----- Server States 2 -----")
       ;; (doseq [s [s0 s1 s2]]

--- a/test/zimbra/simioj/statemachine_test.clj
+++ b/test/zimbra/simioj/statemachine_test.clj
@@ -1,59 +1,53 @@
 (ns zimbra.simioj.statemachine-test
   (:require [clojure.test :refer :all]
             [zimbra.simioj.raft [log :refer :all]]
-            [zimbra.simioj.raft [statemachine :refer :all]]))
+            [zimbra.simioj.raft [statemachine :refer :all]]
+            [zimbra.simioj.raft [server :refer :all]]))
 
 
-(defn- make-log []
-  (make-memory-log [{:id 1 :term 1 :rid 111 :command [:noop {}]}
-                    {:id 2 :term 1 :rid 112 :command [:set-config {:servers [#{} #{:s0}]}]}
-                    {:id 3 :term 1 :rid 113 :command [:patch {:oid 1
-                                                              :upsert {}
-                                                              :ops [#(assoc % :name "widgetmaker")
-                                                                    #(assoc % :city "houston")
-                                                                    #(assoc % :employees 100)]}]}]))
+
+(defrecord TestMachine [servers-config server-state])
 
 
-(deftest memory-statemachine-cmd-set-config
-  (testing "that :set-config commands are processed immediately"
-    (let [log (make-log)
-          cb-state (ref '())
-          cb-fn (fn [old-state new-state] (dosync (ref-set cb-state (list old-state new-state))))
-          sm (make-memory-state-machine :set-config (ref {}) cb-fn)
-          last-applied (process-log! sm log 0 0)]
-      (is (= last-applied 3))
-      (is (= @cb-state (list {} {:servers [#{} #{:s0}]})))
-      (is (= (get-state sm) {:servers [#{} #{:s0}]})))))
+(extend TestMachine
+  StateMachine
+  rsm-state-machine
+  StateChangedNotifier
+  rsm-state-changed-notifier)
 
-(deftest memory-statemachine-cmd-noop
-  (testing "that :noop commands honor commit-index"
-    (let [log (make-log)
-          cb-state (ref '())
-          cb-fn (fn [old-state new-state] (dosync (ref-set cb-state (list old-state new-state))))
-          sm (make-memory-state-machine :noop (ref {}) cb-fn)
-          last-applied-0 (process-log! sm log 0 0)
-          last-applied-1 (process-log! sm log 1 0)
-          last-applied-2 (process-log! sm log 2 1)
-          last-applied-3 (process-log! sm log 3 2)]
-      (is (zero? last-applied-0))
-      (is (= last-applied-1 1))
-      (is (= last-applied-2 2))
-      (is (= last-applied-3 3)))))
 
-(deftest memory-statemachine-cmd-patch
-  (testing "that :patch commands apply correctly"
-    (let [log (make-log)
-          cb-state (ref '())
-          cb-fn (fn [old-state new-state] (dosync (ref-set cb-state (list old-state new-state))))
-          sm (make-memory-state-machine :patch (ref {}) cb-fn)
-          last-applied-0 (process-log! sm log 0 0)
-          last-applied-3 (process-log! sm log 3 0)]
-      (is (zero? last-applied-0))
-      (is (= last-applied-3 3))
-      (is (= (first @cb-state) {:oid 1 :val nil}))
-      (is (= (second @cb-state) {:oid 1 :val {:name "widgetmaker" :city "houston" :employees 100}}))
-      (is (= (post-cmd! log 1 114 [:patch {:oid 1
-                                           :upsert {}
-                                           :ops [#(update-in % [:employees] + 10)]}]) 4))
-      (process-log! sm log 4 last-applied-3)
-      (is (= (get-state sm 1) {:name "widgetmaker" :city "houston" :employees 110})))))
+(defn- make-state-machine [listeners]
+  (TestMachine.
+   {:state-processors {:kv (make-memory-state-processor {} :patch (ref {}))}
+    :state-change-listeners listeners}
+   (ref {:servers [#{:s0}]})))
+
+
+(deftest set-config-cmd-test
+  (testing ":set-config command")
+  (let [cb-state (ref '())
+        cb-fn (fn [cmd ostate nstate] (dosync (ref-set cb-state (list cmd ostate nstate))))
+        sm (make-state-machine {:config [cb-fn]})]
+    (process-set-config! sm [:set-config [#{:s1}]])
+    (is (= (first @cb-state) :set-config))
+    (is (= (second @cb-state) [#{:s0}]))
+    (is (= (nth @cb-state 2) [#{:s1}]))))
+
+
+(deftest patch-cmd-test
+  (testing ":patch command")
+  (let [cb-state (ref '())
+        cb-fn (fn [cmd ostate nstate] (dosync (ref-set cb-state (list cmd ostate nstate))))
+        sm (make-state-machine {:kv [cb-fn]})]
+    (process-command! sm [:patch {:oid 1
+                                  :upsert {}
+                                  :ops [#(assoc % :name "widgetmaker")
+                                        #(assoc % :city "houston")
+                                        #(assoc % :employees 100)]}])
+    (is (= (first @cb-state) :patch))
+    (is (= (second @cb-state) {:oid 1 :val nil}))
+    (is (= (nth @cb-state 2) {:oid 1 :val {:name "widgetmaker" :city "houston" :employees 100}}))
+    (process-command! sm [:patch {:oid 1
+                                  :upsert {}
+                                  :ops [#(update % :employees inc)]}])
+    (is (= (nth @cb-state 2) {:oid 1 :val {:name "widgetmaker" :city "houston" :employees 101}}))))


### PR DESCRIPTION
## statemachine protocol updates

The idea is that we now have the server implement a single statemachine that is responsible for the following:
- Applying configuration changes (list of servers)
- Passing committed commands to the registered state machine processors.  These are wired-in via configuration

The state machine now operates on commands directly and no longer needs to interact with the raft log.
## log configuration updates

All functions used to initialize the raft log are now required to accept an initial argument that provides initialized per-server directories with the following paths available:
- :config
- :state
- :snapshots
## raft server updates

This update include the following:
- Implemented the singleton StateMachine that can now be configured with an arbitrary number of state processors.
- RaftServer now directly implements the following protocols:
  - StateMachine
  - StateChangedNotifier
- Updated initializion code, including new code to initialize a raft from a block of configuration.
- Updated the handling servers-config and server-state so that the :servers and :leader values from servers-config are copied to server-state when initilizing the raft server.
- servers-config is not longer wrapped in a ref as there is nothing that alters its value at runtime.
- configuration changes are applied to server-state now.

Future updates will have the initialization code loading persisted server-state at startup if it exists rather than overwriting it.
## Miscellaneous
- Updated default and sample config
- updated http endpoint for compatibility with new server code
- unit test updates for compatibility with new server, log, and statemachine code
