### PR TITLE
104730 -Implement asynchronous log replication by leader

### DIFF
--- a/resources/defaults.edn
+++ b/resources/defaults.edn
@@ -60,9 +60,8 @@
         ;;   These are all the servers that are members of the Raft cluster
         ;; :state-processers - a map of state-machine-processor initializers
         ;; :state-change-listeners - a map of state-change-listener callback initializers
-        ;; The following initialized directory paths are injected into the :servers-config
-        ;; on start-up, based upon the :prefix and :id
-        ;; :config, :state, :snapshots
+        ;; :max-entries - (integer) max number of entries (commands) to include in a
+        ;;   single append-entries RPC call.
         :servers-config {:servers []}
         ;; Initial server-state.
         ;; Notes: If a server has persisted state when it starts up, the

--- a/resources/defaults.edn
+++ b/resources/defaults.edn
@@ -62,6 +62,8 @@
         ;; :state-change-listeners - a map of state-change-listener callback initializers
         ;; :max-entries - (integer) max number of entries (commands) to include in a
         ;;   single append-entries RPC call.
+        ;; :down-follower-retry (integer, milliseconds) amount of time to wait before
+        ;;   attempting to contact a follower that was down.
         :servers-config {:servers []}
         ;; Initial server-state.
         ;; Notes: If a server has persisted state when it starts up, the

--- a/src/zimbra/simioj/raft/server.clj
+++ b/src/zimbra/simioj/raft/server.clj
@@ -16,11 +16,15 @@
 ;;;; Raft protocol definition
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(def MAX-ENTRIES-DEF
+  "Default value of :max-entries if not specified in :servers-config"
+  5)
+
 (defrecord Entry [^Number term            ; leader's term
                   leader-id               ; leader's ID so followers can redirect
                   ^Number prev-log-index  ; idx of log entry immediatly preceeding
                   ^Number prev-log-term   ; term of prev-log-index entry
-                  entries                 ; entries to store (empty for heartbeat)
+                  entries                 ; entries (commands) to store (empty for heartbeat)
                   ^Number leader-commit]) ; leader's commit-index
 
 (defrecord Vote [^Number term             ; candidate's term
@@ -742,7 +746,9 @@
 ;;;     should be invoked when the state changes.
 ;;;   :leader - if not nil, using configured leader election protocol.  The value
 ;;;     should be the ID of ther server that is supposed to be the leader.
-;;;
+;;;   :max-entries (integer) - the maximum number of entries (commands) to include
+;;;     in a single append-entries RPC.  If not specified the value of
+;;;     MAX-ENTRIES-DEF will be used.
 ;;; server-state - a map that is persisted automatically as values are changed. [ref]
 ;;;   :servers - initialized from servers-config.  After that the values here
 ;;;     override what is in servers-config

--- a/src/zimbra/simioj/raft/server.clj
+++ b/src/zimbra/simioj/raft/server.clj
@@ -16,6 +16,11 @@
 ;;;; Raft protocol definition
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(def DOWN-FOLLOWER-RETRY-DEF
+  "Default value (in milliseconds) of :down-follower-retry if not specified in :servers-config"
+  100)
+
+
 (def MAX-ENTRIES-DEF
   "Default value of :max-entries if not specified in :servers-config"
   5)
@@ -187,7 +192,9 @@
        ;; are meaningless and are not used.
        :conflicting-term <conflicting-term-number>
        :conflicting-first-idx <first-log-index-containing-conflicting-term>}
-    The second form should return a map of
+    The second form should return a map of the following form.  Note that the RPC
+    implementation may return `nil` as the value for a given <server-id> if that
+    server could not be contacted.
     {<server-id> {:term <current-term>
                   :success <boolean>
                   :conflicting-term <conflicting-term-number>
@@ -329,9 +336,20 @@
 (defn- rs-follower-ids
   "Computes the union of all of the sets in the :servers
   vector in the SERVER-STATE ref.
-  Returns a seq"
+  Returns a set"
   [{:keys [:id :server-state]}]
   (disj (apply clojure.set/union (:servers @server-state)) id))
+
+
+(defn- rs-current-follower-ids
+  "Filters out any followers that have an active (non-nil) :updater
+  in :leader-state.
+  Returns a set
+  "
+  [{:keys [:leader-state] :as this}]
+  (clojure.set/difference (rs-follower-ids this)
+                          (map first (filter (comp :updater second) @leader-state))))
+
 
 (defn- rs-election-timeout-ms
   "Computes a random election timeout between the minimum
@@ -562,6 +580,154 @@
     rc))
 
 
+
+(defn- rs-compute-entries-for-follower
+  "Returns an Entry that contains the maximum number of commands allowed
+  based on the term of the log entry in FIRST-INDEX and the max-entries
+  config value.
+  Parameters:
+  LOG - the log instance
+  MAX-ENTRIES - the max number of entries to send in a single append-entries rpc call.
+    All must belong to the same term.
+  LEADER-ID - the id of the leader issuing the append-entries rpc
+  LEADER-NEXT-INDEX - the leaders next-index value
+  LEADER-TERM - the leader's current term
+  LEADER-COMMIT-INDEX - the leaders current commit-index
+  PREV-LOG-INDEX - the previous log index
+  PREV-LOG-TERM - the previous log term
+  FIRST-INDEX - the index of the first entry to send.
+  "
+  [log max-entries leader-id leader-next-index leader-term leader-commit-index
+   prev-log-index prev-log-term first-index]
+  (logger/tracef (str "rs-compute-entries-for-follower: max-entries=%s, leader-id=%s, "
+                     "leader-next-index=%s, leader-term=%s, leader-commit-index=%s, "
+                     "prev-log-index=%s, prev-log-term=%s, first-index=%s")
+                max-entries leader-id, leader-next-index leader-term
+                leader-commit-index prev-log-index prev-log-term first-index)
+  (loop [rentries max-entries
+         entry (get-entry log first-index)
+         lterm (:term (or entry {}))
+         entries []]
+    (logger/tracef (str "rs-compute-entries-for-follower: rentries=%s, "
+                       "entry=%s, lterm=%s, (count entries)=%s")
+                  rentries entry lterm (count entries))
+    (if (and (pos? rentries) entry (= (:term entry) lterm) (< (:id entry) leader-next-index))
+      (recur (dec rentries) (get-entry log (inc (:id entry))) lterm (conj entries entry))
+      (->Entry leader-term leader-id prev-log-index prev-log-term entries leader-commit-index))))
+
+
+(defn- rs-update-follower
+  "This function is run in its own thread and is responsible for bringing a single
+  lagging follower up-to-date.
+  Parameters:
+  this - RaftServer instance
+  follower-id - The ID of the follower that is behind
+  "
+  [{:keys [:id :leader-state :log :rpc :server-state :servers-config] :as this} follower-id]
+  ;; Lookup :next-index and :match-index for follower
+  ;; Compare :match-index with our (leader's (inc last-log-index)
+  ;;   If the same, we are done.  Just update leader-state to set
+  ;;     :updater to nil and exit.
+  ;;   If follower is still behind:
+  ;;     Examine follow's :match-index (it may be 0) and look up
+  ;;      the previous log id and term
+  ;;     Compute the next set of log commands that we can send.
+  ;;     Send the log entries to that follower and update
+  ;;       the :leader-state entry
+  (loop [leader-next-index (inc (first (last-id-term log)))
+         {:keys [:match-index :next-index] :or {:match-index 0 :next-index 1}}
+         (follower-id @leader-state {})]
+    (logger/tracef (str "rs-update-follower: id=%s, follower-id=%s, leader-next-index=%s, "
+                       "match-index=%s, next-index=%s")
+                  id follower-id leader-next-index match-index next-index)
+    (if (= leader-next-index next-index)
+      (dosync (alter leader-state assoc-in [follower-id :updater] nil))
+      (let [{prev-log-index :id prev-log-term :term} (or (get-entry log match-index)
+                                                         {:id 0 :term 0})
+            entry (rs-compute-entries-for-follower log
+                                                   (:max-entries @server-state MAX-ENTRIES-DEF)
+                                                   id
+                                                   leader-next-index
+                                                   (:current-term @server-state)
+                                                   (:commit-index @server-state)
+                                                   prev-log-index
+                                                   prev-log-term
+                                                   (inc match-index))
+            follower-resp (follower-id (append-entries rpc #{follower-id} entry))
+            _ (logger/tracef "rs-update-follower: id=%s, follower-id=%s, follower-resp=%s"
+                            id follower-id follower-resp)
+            [done? new-state] (cond
+                                ;; (1) Server was down, have to sleep and retry
+                                (nil? follower-resp) (do
+                                                       (Thread/sleep (:down-follower-retry @servers-config DOWN-FOLLOWER-RETRY-DEF))
+                                                       [false :leader])
+                                ;; (2) We are no longer the leader
+                                (and (not (:success follower-resp))
+                                     (< (:current-term @server-state)
+                                        (:term follower-resp))) [true :follower]
+                                ;; (3) Entries rejected because we didn't compute things right
+                                (not (:success follower-resp))
+                                (do
+                                  (dosync (alter leader-state
+                                                 update follower-id
+                                                 assoc
+                                                 :next-index (:conflicting-first-idx follower-id 0)
+                                                 :match-index
+                                                 (max 0 (dec (:conflicting-first-idx follower-id 0)))))
+                                  [false :leader])
+                                ;; (4) Successful
+                                :else (do
+                                        (dosync (alter leader-state
+                                                       update follower-id
+                                                       assoc
+                                                       :match-index (+ (:prev-log-index entry) (count (:entries entry)))
+                                                       :next-index (inc (+ (:prev-log-index entry) (count (:entries entry))))))
+                                        (if (= (get-in @leader-state [follower-id :next-index] 0)
+                                               (first (last-id-term log)))
+                                          [true :leader]
+                                          [false :leader])))]
+        (if done?
+          (if (= new-state :leader)
+            (dosync (alter leader-state
+                           assoc-in [follower-id :updater] nil))
+            (follower! this))
+          (recur (inc (first (last-id-term log)))
+                 (follower-id @leader-state {})))))))
+
+
+(defn- rs-process-append-entries!
+  "Inspect the response from append-entries and do the following:
+   1. update :server-state
+   2. if necessary, spawn updaters for any followers that are behind.
+   3. if necessary, reset :updaters for all followers that are current.
+  Parameters:
+   this - RaftServer
+   commit-index - the new commit index
+   resp - the append-entries RPC response. Will be an empty map if there are
+     no current followers.
+  Returns: n/a
+  "
+  [{:keys [:leader-state :server-state] :as this} commit-index resp]
+  (let [all-followers (rs-follower-ids this)
+        successful (into {} (filter (comp :success second) resp))
+        failed (into {} (remove (comp :success second) resp))
+        leader-state-new (reduce
+                          (fn [ls [sid sval]] ;; update state of lagging followers
+                            (assoc ls sid {:next-index (:conflicting-first-idx sval 0)
+                                           :match-index (max 0 (dec (:conflicting-first-idx sval 0)))
+                                           :updater (future (rs-update-follower this sid))}))
+                          (reduce
+                           (fn [ls sid] ;; update state of current follows
+                             (assoc ls sid {:next-index (inc commit-index)
+                                            :match-index commit-index
+                                            :updater nil}))
+                           @leader-state
+                           (keys successful))
+                          failed)]
+    (dosync (alter server-state assoc :commit-index commit-index)
+            (ref-set leader-state leader-state-new))))
+
+
 (defn- rs-command!
   "Send a command to the leader of the state machine.  If COMMAND is nil,
   the system will issue an 'empty' command, like what the leader does when
@@ -575,32 +741,33 @@
 
   (let [{:keys [:commit-index :current-term :state :voted-for] :or
          {:commit-index 0 :current-term 0}} @server-state
-        followers (rs-follower-ids this)
+        all-followers (rs-follower-ids this)
+        followers (rs-current-follower-ids this)
         ;; we implicitly include ourself in the quorum, so this is just the remaining
         ;; quorum we need to commit a log entry
-        min-quorum (quot (inc (count followers)) 2)]
+        min-quorum (quot (inc (count all-followers)) 2)]
 
     (logger/tracef (str "rs-command!-1: id=%s, command?=%s, commit-index=%s, "
-                        "current-term=%s, state=%s, voted-for=%s, min-quorum=%s, "
-                        "followers=%s")
-                   id (some? command) commit-index current-term
-                   state voted-for min-quorum followers)
+                       "current-term=%s, state=%s, voted-for=%s, min-quorum=%s, "
+                       "all-followers=%s, followers=%s")
+                  id (some? command) commit-index current-term
+                  state voted-for min-quorum all-followers followers)
     (cond
       (= state :leader) (try
                           (let [[pidx pterm] (last-id-term log)
                                 new-id (if (nil? command) pidx
-                                           (post-cmd! log current-term rid command))
+                                           (post-cmd! log current-term rid command)) ;; TODO-GOT
                                 {:keys [:applied?]} (process-set-config! this command)
                                 cmd (if (nil? command) []
                                         [{:id new-id :term current-term
                                           :rid rid :command command}])
-                                resp (if (seq? followers) (append-entries
-                                                           rpc
-                                                           followers
-                                                           (->Entry current-term id pidx pterm
-                                                                    cmd
-                                                                    commit-index))
-                                         {})
+                                resp (if (empty? followers) {}
+                                         (append-entries
+                                          rpc
+                                          followers
+                                          (->Entry current-term id pidx pterm
+                                                   cmd
+                                                   commit-index)))
                                 _ (logger/tracef "rs-command!-2: id=%s, append-entries resp=%s" id resp)
                                 num-success (count (filter :success (vals resp)))
                                 max-term (apply max (cons current-term
@@ -615,7 +782,8 @@
                                                           {:status :moved :server sid})
                               (< num-success min-quorum) {:status :unavailable :server id}
                               :else (do
-                                      (dosync (alter server-state assoc :commit-index new-id))
+                                      (rs-process-append-entries! this new-id resp)
+                                      ;;(dosync (alter server-state assoc :commit-index new-id))
                                       (when (and command (not applied?)) (process-command! this command))
                                       {:status :accepted :server id})))
                           (catch IllegalArgumentException iae
@@ -749,6 +917,9 @@
 ;;;   :max-entries (integer) - the maximum number of entries (commands) to include
 ;;;     in a single append-entries RPC.  If not specified the value of
 ;;;     MAX-ENTRIES-DEF will be used.
+;;;   :down-follower-retry (integer, milliseconds) - The amount of time to wait, in
+;;;     milliseconds before attempting to re-connect with a follower.  If not specified,
+;;;     the value of DOWN-FOLLOWER-RETRY-DEF will be used.
 ;;; server-state - a map that is persisted automatically as values are changed. [ref]
 ;;;   :servers - initialized from servers-config.  After that the values here
 ;;;     override what is in servers-config

--- a/test/zimbra/simioj/raft_log_replication_test.clj
+++ b/test/zimbra/simioj/raft_log_replication_test.clj
@@ -1,0 +1,83 @@
+(ns zimbra.simioj.raft-log-replication-test
+  (:require [clojure.test :refer :all]
+            [clojure.tools.logging :as logger]
+            [zimbra.simioj.raft [server :refer :all]]
+            [zimbra.simioj.raft [log :refer :all]]
+            [zimbra.simioj.raft [rpc :refer :all]]))
+
+
+(defn- make-log []
+  (make-memory-log nil [{:id 1 :term 1 :rid 111 :command [:noop {}]}
+                        {:id 2 :term 1 :rid 112 :command
+                         [:patch {:oid 1
+                                  :upsert {}
+                                  :ops [(fn [v] (assoc v :name "widgetmaker"))
+                                        (fn [v] (assoc v :city "houston"))
+                                        (fn [v] (assoc v :employees 100))]}]}
+                        {:id 3 :term 2 :rid 113 :command
+                         [:patch {:oid 1
+                                  :upsert {}
+                                  :ops [(fn [v] (update v :employees inc))
+                                        (fn [v] (assoc v :state "TX"))]}]}]))
+
+
+(deftest leader-update-follower-test
+  (testing "That a leader can bring a follower up to date"
+    (let [sm (ref {})
+          rpc (->TestRpc sm)
+          sc {:servers [#{:s0 :s1 :s2}]}
+          s0 (make-simple-raft-server
+              :s0 (make-log) rpc {} ; id log rpc ec
+              sc
+              {:state :leader :current-term 2 :commit-index 3 :voted-for :s0} ; ss
+              {:s1 {:next-index 4 :match-index 0}}) ; ls
+          s1 (make-simple-raft-server
+              :s1 (make-log) rpc {}
+              sc
+              {:state :follower :current-term 2 :commit-index 2 :voted-for :s0} ; ss
+              {}) ; ls
+          s2 (make-simple-raft-server
+              :s2 (make-memory-log nil) rpc {}
+              sc
+              {:state :follower :current-term 1 :commit-index 0 :voted-for :s0} ; ss
+              {}) ; ls
+          ss0 (:server-state s0)
+          ss1 (:server-state s1)
+          ss2 (:server-state s2)
+          _ (dosync (ref-set sm {:s0 s0 :s1 s1 :s2 s2}))
+          r1 (command! s0 "r1" [:noop {}])]
+      (is (= (:status r1) :accepted))
+      (Thread/sleep 50)
+      (is (= (:status (command! s0 "r2" nil)) :accepted))
+      (is (apply = (map #(last-id-term (:log %)) [s0 s1 s2])))
+      (is (apply = (map #(:current-term @(:server-state %)) [s0 s1 s2])))
+      (is (apply = (map #(:commit-index @(:server-state %)) [s0 s1 s2]))))))
+
+
+  "Returns an Entry that contains the maximum number of commands allowed
+  based on the term of the log entry in FIRST-INDEX and the max-entries
+  config value.
+  Parameters:
+  LOG - the log instance
+  MAX-ENTRIES - the max number of enters to send in a single append-entries rpc call.
+    All must belong to the same term.
+  LEADER-ID - the id of the leader issuing the append-entries rpc
+  LEADER-NEXT-INDEX - the leaders next-index value
+  LEADER-TERM - the leader's current term
+  LEADER-COMMIT-INDEX - the leaders current commit-index
+  PREV-LOG-INDEX - the previous log index
+  PREV-LOG-TERM - the previous log term
+  FIRST-INDEX - the index of the first entry to send."
+
+
+(deftest compute-entries-for-follower-test
+  (testing "private function rs-compute-entries-for-follower"
+    (let [ceff #'zimbra.simioj.raft.server/rs-compute-entries-for-follower
+          log (make-log)
+          entry (ceff log 5 :s0 4 2 3 3 2 1)
+          entry2 (ceff log 5 :s0 4 2 3 3 2 3)]
+      (is (= (count (:entries entry)) 2))
+      (is (= (:id (first (:entries entry))) 1))
+      (is (= (:id (second (:entries entry))) 2))
+      (is (= (count (:entries entry2)) 1))
+      (is (= (:id (first (:entries entry2))) 3)))))


### PR DESCRIPTION
This pull request allows the leader to bring the logs of one or more followers that are behind up-to-date. There are two circumstances where this is required:
- When new server is added to a Raft cluster
- When an existing server has been offline for some period of time and needs 
  to be brought up-to-date.

In both cases, the protocol allows for certain optimizations that minimize the 
time required to perform this task.  This ticket is to specifically cover the 
work required for standard log replication.  

The work required to replicate from snapshots will be covered in a separate 
ticket.
