### PR TITLE
Fix for "null" in url from resource-id.

### DIFF
--- a/src/zimbra/simioj/endpoint/http.clj
+++ b/src/zimbra/simioj/endpoint/http.clj
@@ -101,7 +101,7 @@ POST <command> - Post a command to the Raft
         ret {:status status :body (:state resp)}
         rpc (:rpc raft)]
     (if (contains? #{301 302} status)
-      (assoc ret :headers {"Location" (format "http://%s/state/%s/%s" (@(:servers rpc) (:server resp)) state-machine resource-id)})
+      (assoc ret :headers {"Location" (format "http://%s/state/%s/%s" (@(:servers rpc) (:server resp)) state-machine (if (not resource-id) "" resource-id))})
       ret)))
 
 


### PR DESCRIPTION
If the state-handler is called when no resource is specified and a redirect occurs, the value "null" is appended as the last part of the path in the location header. This can cause problems with clients attempting to use the redirect. Fix is to just not add a value for the last path position if there is no resource-id.
