### PR TITLE
CORS support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,8 @@
                  [org.clojure/core.async "0.2.374"]
                  ;; the following two entries are to support sqlite
                  [org.clojure/java.jdbc "0.3.7"]
-                 [org.xerial/sqlite-jdbc "3.8.9"]]
+                 [org.xerial/sqlite-jdbc "3.8.9"]
+                 [ring-cors "0.1.8"]]
   :main ^:skip-aot zimbra.simioj.main
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}

--- a/resources/defaults.edn
+++ b/resources/defaults.edn
@@ -4,7 +4,11 @@
         :name "node0"
         ;; Inter-node communications
         :endpoint {;; HTTP address:port to bind to
-                   :http "0.0.0.0:2283"}
+                   :http "0.0.0.0:2283"
+                   ;; CORS
+                   :access-control-allow-origin [".*"]
+                   :access-control-allow-methods [:get :post]
+                   }
         ;; Jetty configuration
         :worker {:count 4 :threads 4}
         ;; This location is added to the classpath and should contain

--- a/src/zimbra/simioj/endpoint/http.clj
+++ b/src/zimbra/simioj/endpoint/http.clj
@@ -6,6 +6,7 @@
    [compojure.core :refer :all]
    [ring.adapter.jetty :refer [run-jetty]]
    [ring.util.request :refer :all]
+   [ring.middleware.cors :refer [wrap-cors]]
    [zimbra.simioj.endpoint.middleware :refer :all]
    [zimbra.simioj.raft.server :refer :all])
   (:gen-class))
@@ -145,9 +146,12 @@ POST <command> - Post a command to the Raft
 (defn- endpoint-app
   "Wraps the provided routes with json or edn filtering"
   [ctx]
-  (wrap-response
+  (wrap-cors
+   (wrap-response
    (routes
-    (app-routes ctx))))
+    (app-routes ctx)))
+   :access-control-allow-origin [#".*"]
+   :access-control-allow-methods [:get :post]))
 
 
 (defn start!

--- a/src/zimbra/simioj/endpoint/http.clj
+++ b/src/zimbra/simioj/endpoint/http.clj
@@ -150,8 +150,11 @@ POST <command> - Post a command to the Raft
    (wrap-response
    (routes
     (app-routes ctx)))
-   :access-control-allow-origin [#".*"]
-   :access-control-allow-methods [:get :post]))
+   :access-control-allow-origin
+   (map re-pattern
+        (get-in @ctx [:config :node :endpoint :access-control-allow-origin] ".*"))
+   :access-control-allow-methods
+   (get-in @ctx [:config :node :endpoint :access-control-allow-methods] [:get :post])))
 
 
 (defn start!


### PR DESCRIPTION
Add support for CORS. Options are available in the endpoint config allowing you to specify a list of strings (interpreted as regular expressions) for the allowed origins.
