### PR TITLE
update state transition logic

### DIFF
--- a/src/zimbra/simioj/raft/server.clj
+++ b/src/zimbra/simioj/raft/server.clj
@@ -450,7 +450,6 @@
   for a RaftServer"
   [{:keys [:election-config :id :log :timers :servers-config :server-state]
     :as this}]
-  (cancel-timers! this)
   (let [leader (:leader @server-state)]
     (logger/tracef "rs-follower!: id=%s, leader=%s, server-state=%s, last-id-term=%s"
                    id leader @server-state (last-id-term log))
@@ -778,8 +777,6 @@
                                                                       (fn [[s {:keys [:success :term]}]]
                                                                         (and (not success) (= term max-term)))
                                                                       resp))]
-                                                          (dosync (alter server-state assoc :state :follower))
-                                                          (start-timers! this)
                                                           {:status :moved :server sid})
                               (< num-success min-quorum) {:status :unavailable :server id}
                               :else (do


### PR DESCRIPTION
- remove the call to cancel-timers at the top of rs-follower!
- rs-command! no longer converts state to follower and starts
  timers when the potential leader's term is behind.  That is
  already handled by the code that processes the response from that
  function.
